### PR TITLE
Revert "source the env vars to allow app boot"

### DIFF
--- a/scripts/docker/start.sh
+++ b/scripts/docker/start.sh
@@ -4,9 +4,4 @@ cd /rails_app
 mkdir -p tmp/pids/
 rm -f tmp/pids/*.pid
 
-if [ -f "/run/secrets/environment" ]
-then
-    source /run/secrets/environment
-fi
-
 exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Reverts zooniverse/zoo-stats-api-graphql#20 

switch from sourcing env vars to using the rails credentials manager.