### PR TITLE
Remove trailing whitespace from commit_id

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,9 @@ class ApplicationController < ActionController::API
 
   private
   def fetch_commit_id
-    Rails.cache.fetch("commit_id", expires_in: 10.days) do
+    commit_id = Rails.cache.fetch("commit_id", expires_in: 10.days) do
       File.read(File.expand_path("../../../commit_id.txt", __FILE__))
     end
+    commit_id.strip
   end
 end

--- a/spec/zoo_stats_api_graphql_request_spec.rb
+++ b/spec/zoo_stats_api_graphql_request_spec.rb
@@ -3,7 +3,7 @@ Rspec.describe 'ZooStatsApiGraphql', type: :request do
     before do
       expect(ActiveRecord::Base.connection).to receive(:execute).with("SELECT 1 FROM events").and_return("test response")
       cache_store = Rails.cache
-      expect(cache_store).to receive(:fetch).with("commit_id", expires_in: 10.days).and_return("test commit")
+      expect(cache_store).to receive(:fetch).with("commit_id", expires_in: 10.days).and_return("test commit\n")
     end
     it 'should return a health check response' do
       get '/'


### PR DESCRIPTION
Remove trailing `\n` from commit_id in health check