### PR TITLE
Add required window variable to limit the query search space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-/.DS_Store
+.DS_Store
 */.DS_Store
 
 # Ignore uploaded files in development

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ curl -d '{"query": "{__schema {queryType {name fields {name}}mutationType {name 
 **Event type counts per interval**
 Retrieve the number of classifications for a specified event type for a known interval. Non-required attributes are `projectID` and `userId` to filter the results.
 
-Note: If you supply the the userId attribute you **must** provide a bearer token in the Authorization header, e.g. 
+Note: If you supply the the userId attribute you **must** provide a bearer token in the Authorization header, e.g.
 `Authorization: Bearer <TOKEN>`
 
 You must supply and `eventType` and `interval`. Valid intervals are postgres intervals, e.g. `2 Days`, `24 Hours`, `60 Seconds`
@@ -67,6 +67,10 @@ Once all the above steps complete you will have a working copy of the checked ou
 
 0. Run the tests
     * Run: `docker-compose run -T --rm -e RAILS_ENV=test --entrypoint="bundle exec rspec" zoo_stats`
+
+0. Get a console to interactively run / debug tests
+    * Run: `docker-compose run --rm -e RAILS_ENV=test --entrypoint="/bin/bash" zoo_stats`
+    * Then in the container run: `bundle exec rspec`
 
 ### Setup Docker and Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ Retrieve the number of classifications for a specified event type for a known in
 Note: If you supply the the userId attribute you **must** provide a bearer token in the Authorization header, e.g.
 `Authorization: Bearer <TOKEN>`
 
-You must supply and `eventType` and `interval`. Valid intervals are postgres intervals, e.g. `2 Days`, `24 Hours`, `60 Seconds`
+You must supply and `eventType`, `interval` and `window`. Valid intervals are postgres intervals, e.g. `2 Days`, `24 Hours`, `60 Seconds`
+Valid windows are postgres intervals, e.g. `7 Days`, `2 Weeks`, `1 Month`, `1 Year`.
 
 ```
 {
   statsCount(
     eventType: "classification",
     interval: "1 Day",
+    window: "1 week",
     projectId: "${project.id}",
     userId: "${user.id}"
   ){

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -8,6 +8,7 @@ module Types
       description 'returns counts of event types grouped by interval (e.g. "1 day") with optional filtering by user, project and workflow ids'
       argument :interval, String, required: true
       argument :event_type, String, required: true
+      argument :window, String, required: true
       argument :user_id, ID, required: false
       argument :project_id, ID, required: false
       argument :workflow_id, ID, required: false

--- a/app/graphql/utilities/searchers.rb
+++ b/app/graphql/utilities/searchers.rb
@@ -1,8 +1,14 @@
 module Searchers
   class Bucket
-    def self.search(kwargs)
-      time_bucket = kwargs.delete(:interval)
-      Event.select("time_bucket('#{time_bucket}', event_time) AS period, count(*)").group("period").where(**kwargs)
+    def self.search(query_filters)
+      time_bucket = query_filters.delete(:interval)
+      window = query_filters.delete(:window)
+      Event.select(
+          "time_bucket('#{time_bucket}', event_time) AS period, count(*)"
+        )
+        .group("period")
+        .where(**query_filters)
+        .where("event_time >= NOW() - INTERVAL ?", window)
     end
   end
 end

--- a/spec/graphql/utilities/searchers_spec.rb
+++ b/spec/graphql/utilities/searchers_spec.rb
@@ -5,14 +5,16 @@ RSpec.describe Searchers do
     let(:users_id) { 123 }
     let(:event_types) { 'classification' }
     let(:time_bucket) { '1 day' }
+    let(:window) { '1 Week' }
     let(:arguments) do
       {
         interval:    time_bucket,
-        user_id:        users_id,
-        event_type:     event_types
+        user_id:     users_id,
+        event_type:  event_types,
+        window:      window
       }
     end
-    let(:start_time) { Time.zone.parse('2018-11-06 10:30:10') }
+    let(:start_time) { Time.zone.now - 4.days }
     let!(:generic_classifications) { create_list(:event, 3, event_time: start_time, event_type: 'classification') }
     let!(:generic_comments) { create_list(:event, 3, event_time: start_time, event_type: 'comment') }
 

--- a/spec/graphql/zoo_stats_schema_spec.rb
+++ b/spec/graphql/zoo_stats_schema_spec.rb
@@ -37,7 +37,7 @@ RSpec.shared_examples 'a statsCount query' do |input|
   end
 
   context 'when there are matching events' do
-    let(:start_time) { Time.zone.parse('2018-11-06 05:45:09') }
+    let(:start_time) { Time.zone.now - 4.days }
     let(:attributes_matching_time_1) do
       base_attributes.merge({
         user_id:     123,
@@ -59,8 +59,8 @@ RSpec.shared_examples 'a statsCount query' do |input|
     let!(:events_type_2) { create_list(:event, 2, **attributes_matching_time_2) }
     let(:output) do
       output = [
-        {"period"=>"2018-11-06T00:00:00Z", "count"=>1},
-        {"period"=>"2018-11-08T00:00:00Z", "count"=>2}
+        {'period'=>start_time.beginning_of_day.iso8601, 'count'=>1},
+        {'period'=>mid_time.beginning_of_day.iso8601, 'count'=>2},
       ]
     end
     it 'returns correct events' do
@@ -72,8 +72,8 @@ end
 RSpec.describe ZooStatsSchema do
   describe 'statsCount' do
     context 'with a queried projectId' do
-      query_string = "query ($projectId: ID!, $eventType: String!, $interval: String!){
-        statsCount(projectId: $projectId, eventType: $eventType, interval: $interval){
+      query_string = "query ($projectId: ID!, $eventType: String!, $interval: String!, $window: String!){
+        statsCount(projectId: $projectId, eventType: $eventType, interval: $interval, window: $window){
           period,
           count
         }
@@ -81,15 +81,16 @@ RSpec.describe ZooStatsSchema do
       variables = {
         "projectId": 456,
         "eventType": 'classification',
-        "interval": '1 day'
+        "interval": '1 day',
+        "window": '1 week'
       }
 
       it_behaves_like 'a statsCount query', { query_string: query_string, variables: variables }
     end
 
     context 'with a queried workflowId' do
-      query_string = "query ($workflowId: ID!, $eventType: String!, $interval: String!){
-        statsCount(workflowId: $workflowId, eventType: $eventType, interval: $interval){
+      query_string = "query ($workflowId: ID!, $eventType: String!, $interval: String!, $window: String!){
+        statsCount(workflowId: $workflowId, eventType: $eventType, interval: $interval, window: $window){
           period,
           count
         }
@@ -97,15 +98,16 @@ RSpec.describe ZooStatsSchema do
       variables = {
         "workflowId": 789,
         "eventType": 'classification',
-        "interval": '1 day'
+        "interval": '1 day',
+        "window": '1 week'
       }
-      
+
       it_behaves_like 'a statsCount query', { query_string: query_string, variables: variables }
     end
 
     context 'with a queried userId' do
-      query_string = "query ($userId: ID!, $eventType: String!, $interval: String!){
-        statsCount(userId: $userId, eventType: $eventType, interval: $interval){
+      query_string = "query ($userId: ID!, $eventType: String!, $interval: String!, $window: String!){
+        statsCount(userId: $userId, eventType: $eventType, interval: $interval, window: $window){
           period,
           count
         }
@@ -113,9 +115,10 @@ RSpec.describe ZooStatsSchema do
       variables = {
         "userId": 123,
         "eventType": 'classification',
-        "interval": '1 day'
+        "interval": '1 day',
+        "window": '1 week'
       }
-      
+
       it_behaves_like 'a statsCount query', { query_string: query_string, variables: variables }
     end
 
@@ -132,12 +135,14 @@ RSpec.describe ZooStatsSchema do
       let(:variables) do
         {
           "eventType": 'classification',
-          "interval": '1 day'
+          "interval": '1 day',
+          "window": '1 week'
+
         }
       end
       let(:query_string) do
-        "query ($eventType: String!, $interval: String!){
-          statsCount(eventType: $eventType, interval: $interval){
+        "query ($eventType: String!, $interval: String!, $window: String!){
+          statsCount(eventType: $eventType, interval: $interval, window: $window){
             period,
             count
           }
@@ -166,12 +171,13 @@ RSpec.describe ZooStatsSchema do
         {
           "userId": current_user,
           "eventType": 'classification',
-          "interval": '1 day'
+          "interval": '1 day',
+          "window": '1 week'
         }
       end
       let(:query_string) do
-        "query ($userId: ID!, $eventType: String!, $interval: String!){
-          statsCount(userId: $userId, eventType: $eventType, interval: $interval){
+        "query ($userId: ID!, $eventType: String!, $interval: String!, $window: String!){
+          statsCount(userId: $userId, eventType: $eventType, interval: $interval, window: $window){
             period,
             count
           }
@@ -182,7 +188,7 @@ RSpec.describe ZooStatsSchema do
       let(:attributes) do
         {
           user_id: current_user,
-          event_time: Time.zone.parse('2018-11-06 05:45:09'),
+          event_time: Time.zone.now - 1.day,
           event_type: 'classification'
         }
       end
@@ -195,7 +201,7 @@ RSpec.describe ZooStatsSchema do
           expect(output["errors"].first["message"]).to eq("Permission denied")
         end
       end
-    
+
       context 'when the queried :user_id is not :current_user' do
         let(:context) { {current_user: wrong_user} }
         it 'returns no events' do
@@ -204,14 +210,14 @@ RSpec.describe ZooStatsSchema do
           expect(output["errors"].first["message"]).to eq("Permission denied")
         end
       end
-    
+
       context 'when the current user is an :admin' do
         let(:context) { {admin: true} }
         it 'returns correct events' do
           expect(result["data"]["statsCount"]).not_to be_empty
         end
       end
-      
+
       context 'when the queried :user_id is :current_user' do
         let(:context) { {current_user: current_user} }
         it 'returns correct events' do


### PR DESCRIPTION
Ensure we have timely queries, focus the window of data that a query will calculate the buckets for. I.e. window: '1 week' or '7 days' etc

https://www.2ndquadrant.com/en/blog/know-what-time-it-is/
Valid interval periods are 
```
YEAR
MONTH
DAY
HOUR
MINUTE
SECOND
```