### PR TITLE
Add nginx config to repo

### DIFF
--- a/kubernetes/nginx.yaml
+++ b/kubernetes/nginx.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  nginx.conf: |+
+    upstream app {
+      server zoo-event-stats-grafana-app:3000;
+    }
+
+    server {
+      access_log /dev/stdout main;
+      error_log /dev/stdout;
+      auth_basic "Restricted Area";
+      auth_basic_user_file /etc/nginx/.htpasswd;
+
+      location / {
+        proxy_pass http://app;
+        proxy_set_header Authorization "";
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: zoo-event-stats-grafana-nginx-config


### PR DESCRIPTION
This new file creates the same (in contents & name) ConfigMap that currently exists in the AWS cluster so that it's properly created when the kubernetes folder is applied on deploy. Nothing else should need to change since grafana.yaml just mounts the contents of the config map by name.