### PR TITLE
500 error on problematic graphql mutation payloads

### DIFF
--- a/app/graphql/zoo_stats_schema.rb
+++ b/app/graphql/zoo_stats_schema.rb
@@ -1,6 +1,4 @@
 class ZooStatsSchema < GraphQL::Schema
-  rescue_from(ActiveRecord::RecordInvalid) { |error| error.message }
-
   mutation(Types::MutationType)
   query(Types::QueryType)
 end


### PR DESCRIPTION
ensure we have visibility into problematic payloads or issues with schema (missing PK constrain anyone?)

Noting that graphql end points will return 200 even for errored states
https://graphql-ruby.org/mutations/mutation_errors
https://github.com/rmosolgo/graphql-ruby/blob/master/guides/errors/execution_errors.md

As such we don't handle anything but a 500 error via our current lambda function, https://github.com/zooniverse/zoo-stats-api-graphql/blob/965ac156ad38281458fe347fdf9be5a21249db6d/kinesis-to-http/zoo-stats-api-graphql.py#L20

this is a compromise fix to include error reporting via rollbar and ensure we backup the lambda function to avoid missing data in the app.

Long term the fix is to reflect on the response object error keys in the lambda function handler and handle errors manually in the mutation for error app reporting