### PR TITLE
avoid OOM killing and fix liveness probes

### DIFF
--- a/kubernetes/grafana.yaml
+++ b/kubernetes/grafana.yaml
@@ -34,14 +34,14 @@ spec:
           image: grafana/grafana:5.3.2
           resources:
                requests:
-                 memory: "30Mi"
+                 memory: "100Mi"
                  cpu: "10m"
                limits:
-                 memory: "30Mi"
+                 memory: "500Mi"
                  cpu: "500m"
           livenessProbe:
             httpGet:
-              path: /
+              path: /login
               port: 3000
             initialDelaySeconds: 2
             periodSeconds: 10
@@ -91,10 +91,10 @@ spec:
           image: zooniverse/apps-nginx:xenial
           resources:
                requests:
-                 memory: "60Mi"
+                 memory: "100Mi"
                  cpu: "10m"
                limits:
-                 memory: "60Mi"
+                 memory: "100Mi"
                  cpu: "500m"
           livenessProbe:
             tcpSocket:

--- a/kubernetes/grafana.yaml
+++ b/kubernetes/grafana.yaml
@@ -34,7 +34,7 @@ spec:
           image: grafana/grafana:5.3.2
           resources:
                requests:
-                 memory: "100Mi"
+                 memory: "500Mi"
                  cpu: "10m"
                limits:
                  memory: "500Mi"


### PR DESCRIPTION
allow more RAM for grafana and nginx to avoid OOM killer errors (see below). Also fix the liveness probe to use the `/` redirect target `/login`.
```
zoo-event-stats-grafana-nginx:
....
    State:          Running
      Started:      Tue, 02 Jun 2020 07:58:18 +0100
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Mon, 01 Jun 2020 07:45:59 +0100
      Finished:     Tue, 02 Jun 2020 07:58:15 +0100
    Ready:          True
    Restart Count:  6
```