### PR TITLE
add fsGroup owner for mounted volumes

### DIFF
--- a/kubernetes/grafana.yaml
+++ b/kubernetes/grafana.yaml
@@ -50,6 +50,8 @@ spec:
           volumeMounts:
           - name: zoo-event-stats-grafana-data
             mountPath: "/var/lib/grafana"
+      securityContext:
+        fsGroup: 2000
       volumes:
       - name: zoo-event-stats-grafana-data
         persistentVolumeClaim:


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
Allow the grafana user to access the attached persistent volume