### PR TITLE
stop running grafana and nginx

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -21,9 +21,9 @@ spec:
           resources:
                requests:
                  memory: "350Mi"
-                 cpu: "250m"
+                 cpu: "100m"
                limits:
-                 memory: "350Mi"
+                 memory: "500Mi"
                  cpu: "500m"
           imagePullPolicy: Always
           livenessProbe:

--- a/kubernetes/grafana.yaml
+++ b/kubernetes/grafana.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app: zoo-event-stats-grafana-app
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: zoo-event-stats-grafana-app
@@ -34,7 +34,7 @@ spec:
           image: grafana/grafana:5.3.2
           resources:
                requests:
-                 memory: "500Mi"
+                 memory: "100Mi"
                  cpu: "10m"
                limits:
                  memory: "500Mi"
@@ -77,7 +77,7 @@ metadata:
   labels:
     app: zoo-event-stats-grafana-nginx
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: zoo-event-stats-grafana-nginx


### PR DESCRIPTION
these aren't in use so we can scale the replica count to 0 (we can easily bring these back in future). Also this PR updates the k8s resource RAM / CPU requests and limits for better pod scheduling and packing.