### PR TITLE
handle invalid jwt signature verification errors

### DIFF
--- a/app/graphql/utilities/credential.rb
+++ b/app/graphql/utilities/credential.rb
@@ -23,7 +23,7 @@ class Credential
   def logged_in?
     return false unless jwt_payload.present?
     jwt_payload['login'].present?
-  rescue JWT::ExpiredSignature
+  rescue JWT::ExpiredSignature, JWT::VerificationError
     false
   end
 


### PR DESCRIPTION
sometimes folks try and use a staging JWT token for the production stats service and the signing keys don't match - handle this gracefully instead of raising